### PR TITLE
Add the ability to create multiple choice question

### DIFF
--- a/docs/css/coding-guidelines.md
+++ b/docs/css/coding-guidelines.md
@@ -104,9 +104,9 @@ h3 {
 Where quotes can or should be included, use them, and use double quotes. For example:
 
 ```css
-[data-vegetable="liquid"] {
+[data-vegetable='liquid'] {
   background-color: goldenrod;
-  background-image: url("../../media/examples/lizard.png");
+  background-image: url('../../media/examples/lizard.png');
 }
 ```
 
@@ -168,7 +168,9 @@ h3 {
 
 ```css
 /* Bad Approach */
-h1, h2, h3 {
+h1,
+h2,
+h3 {
   font-family: sans-serif;
   text-align: center;
 }
@@ -210,7 +212,11 @@ p {
 
 ```css
 /* Bad Approach */
-p { color: white; background-color: black; padding: 1rem; }
+p {
+  color: white;
+  background-color: black;
+  padding: 1rem;
+}
 ```
 
 ---

--- a/docs/welcome/mdx.md
+++ b/docs/welcome/mdx.md
@@ -24,9 +24,11 @@ export const Highlight = ({children, color}) => ( <span style={{
 
 We can also get a little creative with it. Below are two examples of the same `Quiz` component with different props. Can you try and answer the following questions?
 
-<Quiz name="quiz1" question="What function allows you to render React content in an HTML page?" answer="ReactDOM.render()" options={[ 'ReactDOM.start()', 'ReactDOM.render()', 'React.render()', 'React.mount()', 'React.memo()' ]} />
+<Quiz name="quiz1" question="What function allows you to render React content in an HTML page?" answer="ReactDOM.render()" choices={[ 'ReactDOM.start()', 'ReactDOM.render()', 'React.render()', 'React.mount()', 'React.memo()' ]} />
 
-<Quiz name="quiz2" question="Which hook is used to create states inside functional components" answer="React.useState" options={[ 'ReactDOM.useState', 'ReactDOM.useHookState', 'React.useState', 'React.useHookState' ]} />
+<Quiz name="quiz2" question="Which hook is used to create states inside functional components?" answer="React.useState" choices={[ 'ReactDOM.useState', 'ReactDOM.useHookState', 'React.useState', 'React.useHookState' ]} />
+
+<Quiz name="quiz3" question="What are the different ways to share data in React?" answers={[ 'State', 'Prop', 'Context' ]} choices={[ 'State', 'Country', 'District', 'Context', 'Prop' ]} />
 
 Of course the following `EditedBy` is also a shared component. It takes name and date as props :smile:
 

--- a/src/components/CheckIcon/index.js
+++ b/src/components/CheckIcon/index.js
@@ -1,12 +1,12 @@
 import React from 'react';
 
-export default () => (
+export default ({isCorrect}) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     height="24"
     viewBox="0 0 24 24"
     width="24"
-    fill="#00a400">
+    fill={isCorrect ? '#00a400' : '#a0a0a0'}>
     <path d="M0 0h24v24H0z" fill="none" />
     <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
   </svg>

--- a/src/components/Quiz/index.js
+++ b/src/components/Quiz/index.js
@@ -8,22 +8,44 @@ import RadioIcon from '../RadioIcon';
 import CheckIcon from '../CheckIcon';
 import CancelIcon from '../CancelIcon';
 
-export default ({question, name, answer, options}) => {
-  const [disabled, setdisabled] = useState(false);
-  const [choosen, setChoosen] = useState();
+export default ({question, name, answer, answers, choices}) => {
+  const isMultipleChoice = Array.isArray(answers);
+  const [isComplete, setIsComplete] = useState(false);
+  const [isCorrect, setIsCorrect] = useState(false);
+  const [chosen, setChosen] = useState([]);
 
   const onChange = (e) => {
-    setChoosen(e.target.value);
-    setdisabled(true);
+    if (isMultipleChoice) {
+      const uniqueItems = [...new Set([...chosen, e.target.value])];
+
+      setChosen(uniqueItems);
+      setStatus(uniqueItems);
+    } else {
+      setChosen([e.target.value]);
+      setStatus(e.target.value);
+    }
   };
 
-  const noborder = (index) =>
-    options.length % 2 === 0 && index + 2 === options.length;
+  const noBorder = (index) =>
+    choices.length % 2 === 0 && index + 2 === choices.length;
 
   const getIcon = (option) => {
-    if (disabled && option === answer) return <CheckIcon />;
+    const matchAnswer = isMultipleChoice
+      ? answers.includes(option)
+      : option === answer;
+    const matchChosen = isMultipleChoice
+      ? Boolean(chosen.find((item) => option === item))
+      : option === chosen[0];
 
-    if (disabled && option === choosen) return <CancelIcon />;
+    if (isComplete && matchAnswer) {
+      return <CheckIcon isCorrect />;
+    }
+
+    if (isComplete && !isCorrect && matchChosen) {
+      return <CancelIcon />;
+    } else if (isMultipleChoice && matchChosen) {
+      return <CheckIcon />;
+    }
 
     return (
       <>
@@ -33,28 +55,77 @@ export default ({question, name, answer, options}) => {
           name={name}
           value={option}
           onChange={onChange}
-          disabled={disabled}
+          disabled={isComplete}
         />
         <RadioIcon className={styles.input} />
       </>
     );
   };
 
+  const setStatus = (value) => {
+    const selectedItems = value ?? chosen;
+
+    if (isMultipleChoice) {
+      for (let i = 0, j = selectedItems.length; i < j; i++) {
+        const item = selectedItems[i];
+
+        if (!answers.includes(item)) {
+          setIsComplete(true);
+          setIsCorrect(false);
+          break;
+        }
+
+        if (i + 1 === j) {
+          if (j === answers.length) {
+            setIsComplete(true);
+            setIsCorrect(true);
+          } else {
+            setIsComplete(false);
+          }
+        }
+      }
+    } else {
+      setIsComplete(true);
+      setIsCorrect(selectedItems === answer);
+    }
+  };
+
+  const onReset = () => {
+    setIsComplete(false);
+    setIsCorrect(false);
+    setChosen([]);
+  };
+
   return (
     <form
       className={`${styles.form} ${
-        disabled ? (choosen === answer ? styles.success : styles.failed) : ''
+        isComplete ? (isCorrect ? styles.success : styles.failed) : ''
       }`}>
-      <p className={styles.question}>{question}</p>
-      <div className={styles.options}>
-        {options.map((option, index) => (
+      <p className={styles.question}>
+        {question}
+        {isMultipleChoice ? <small>Choose multiple</small> : null}
+      </p>
+      {isComplete ? (
+        <button
+          className={`${styles.info} ${styles.action}`}
+          type="button"
+          onClick={onReset}>
+          Reset
+        </button>
+      ) : (
+        <small className={styles.info}>
+          {isMultipleChoice ? 'Multiple' : 'Single'}
+        </small>
+      )}
+      <div className={styles.choices}>
+        {choices.map((choice, index) => (
           <div
-            key={option}
-            className={`${styles.option} ${
-              noborder(index) ? styles.noBorderBottom : ''
+            key={choice}
+            className={`${styles.choice} ${
+              noBorder(index) ? styles.noBorderBottom : ''
             }`}>
-            {getIcon(option)}
-            <label htmlFor={option}>{option}</label>
+            {getIcon(choice)}
+            <label htmlFor={choice}>{choice}</label>
           </div>
         ))}
       </div>

--- a/src/components/Quiz/styles.module.css
+++ b/src/components/Quiz/styles.module.css
@@ -6,6 +6,7 @@
   margin: 40px 0;
   color: var(--color);
   transition: border-color 0.2s ease, color 0.2s ease;
+  position: relative;
 }
 
 .form.success {
@@ -24,44 +25,44 @@
   border-bottom: 1px solid var(--border-color);
 }
 
-.options {
+.choices {
   display: flex;
   flex-flow: column;
 }
 
 @media (min-width: 786px) {
-  .options {
+  .choices {
     flex-flow: row;
     flex-wrap: wrap;
   }
 }
 
-.option {
+.choice {
   flex: 0 50%;
   padding: 20px;
   position: relative;
 }
 
-.option:not(:last-child) {
+.choice:not(:last-child) {
   border-bottom: 1px solid var(--border-color);
 }
 
-.option.noBorderBottom {
+.choice.noBorderBottom {
   border-bottom: none;
 }
 
 @media (min-width: 786px) {
-  .option:nth-child(odd) {
+  .choice:nth-child(odd) {
     border-right: 1px solid var(--border-color);
   }
 }
 
-.option input {
+.choice input {
   position: absolute;
   left: -999px;
 }
 
-.option label {
+.choice label {
   position: absolute;
   left: 0;
   right: 0;
@@ -71,19 +72,19 @@
   cursor: pointer;
 }
 
-.form.success .option label,
-.form.failed .option label {
+.form.success .choice label,
+.form.failed .choice label {
   cursor: default;
 }
 
-.option svg {
+.choice svg {
   position: relative;
   top: 6px;
   animation: appear 0.2s ease;
 }
 
-.form.success .option .input,
-.form.failed .option .input {
+.form.success .choice .input,
+.form.failed .choice .input {
   opacity: 0.3;
 }
 
@@ -96,4 +97,22 @@
     opacity: 1;
     transform: scale(1);
   }
+}
+
+.info {
+  --color: var(--ifm-hr-background-color);
+  position: absolute;
+  right: 10px;
+  top: 10px;
+  border: 1px solid var(--border-color);
+  color: var(--color);
+  background-color: transparent;
+  border-radius: 5px;
+  padding: 5px 8px;
+  line-height: 1;
+}
+
+.info.action {
+  --color: var(--ifm-color-danger);
+  cursor: pointer;
 }


### PR DESCRIPTION
The `Quiz` component on FEED-docs can now show multiple choice questions:
```jsx
<Quiz
  name="quiz1"
  question="What are the different ways to share data in React?"
  answers={[ 'State', 'Prop', 'Context' ]}
  choices={[ 'State', 'Country', 'District', 'Context', 'Prop' ]} 
/>
```

The old version is still supported. Pass the `answer` prop for single choice question
```jsx
<Quiz
  name="quiz2"
  question="Which hook is used to create states inside functional components?"
  answer="React.useState"
  choices={[ 'ReactDOM.useState', 'ReactDOM.useHookState', 'React.useState', 'React.useHookState' ]}
/>
```

Other changes:
- Renamed `options` prop to `choices`
- Updated example on MDX page